### PR TITLE
Implement traits for comet_extra types

### DIFF
--- a/crates/comet-extra/src/alloc/string.rs
+++ b/crates/comet-extra/src/alloc/string.rs
@@ -58,6 +58,7 @@ pub struct FromUtf8Error<H: GcBase> {
 pub struct FromUtf16Error(());
 
 /// GCed version of [alloc::string::String] It has all the same features as std String.
+#[derive(Clone)]
 pub struct String<H: GcBase> {
     vec: Vector<u8, H>,
 }

--- a/crates/comet-extra/src/alloc/vector.rs
+++ b/crates/comet-extra/src/alloc/vector.rs
@@ -727,6 +727,10 @@ unsafe impl<T: Trace, H: GcBase> Trace for Vector<T, H> {
     }
 }
 
+unsafe impl<T: Trace, H: GcBase> Finalize for Vector<T, H> {}
+
+impl<T: Trace, H: GcBase> Collectable for Vector<T, H> {}
+
 #[repr(C)]
 struct VectorStorage<T: Trace + 'static> {
     length: AtomicU32,

--- a/crates/comet-extra/src/alloc/vector.rs
+++ b/crates/comet-extra/src/alloc/vector.rs
@@ -12,6 +12,7 @@ use core::sync::atomic::Ordering;
 /// `Vector` is a space-optimized GCed implementation of `alloc::vec::Vec` that is only the size of a single pointer and
 /// also extends portions of its API. In many cases, it is a drop-in replacement for the "real" `Vec`.
 #[repr(transparent)]
+#[derive(Clone)]
 pub struct Vector<T: Trace + 'static, H: GcBase> {
     storage: Gc<VectorStorage<T>, H>,
 }


### PR DESCRIPTION
Addresses #5 

* `Clone` allows the `Gc` pointers within the types to be copied to allow aliasing.
* `Collectable` allows `Vector` to be stored inside a `Gc<T>`, e.g:
```rust
struct Bar {
    foo: Gc<Foo>
}
struct Foo {
    x: Vector<i32>,
    y: Vector<i32>,
}
```